### PR TITLE
Renamed exceptions

### DIFF
--- a/mozilla_password_decrypt/cli.py
+++ b/mozilla_password_decrypt/cli.py
@@ -13,10 +13,10 @@ from argparse import ArgumentParser
 from collections import namedtuple
 from glob import glob
 
-from .decrypt import (
-    Base64DecodingFailedException, NssInitializationFailedException,
-    NssLinkingFailedException, PasswordDecryptionFailedException,
-    decrypt_single)
+from .errors import (
+    Base64DecodingError, NssInitializationError, NssLinkingError,
+    PasswordDecryptionError)
+from .decrypt import decrypt_single
 
 
 MOZLOGIN = [  # Format of mozilla signons SQLite database
@@ -102,20 +102,20 @@ def main():
                 try:
                     decrypted_text = \
                         decrypt_single(profile_path, encrypted_text_encoded)
-                except NssInitializationFailedException:
+                except NssInitializationError:
                     print('NSS initialization failed for profile path "%s".'
                           % profile_path, file=sys.stderr)
                     sys.exit(1)
-                except NssLinkingFailedException as e:
+                except NssLinkingError as e:
                     print('Dynamically linking to NSS failed: %s' % e,
                         file=sys.stderr)
                     sys.exit(1)
-                except Base64DecodingFailedException:
+                except Base64DecodingError:
                     print('Base64 decoding failed (database "%s", id %d).'
                           % (filename, _id), file=sys.stderr)
                     success = False
                     continue
-                except PasswordDecryptionFailedException:
+                except PasswordDecryptionError:
                     print('Password decryption failed (database "%s", id %d).'
                           % (filename, _id), file=sys.stderr)
                     success = False

--- a/mozilla_password_decrypt/errors.py
+++ b/mozilla_password_decrypt/errors.py
@@ -1,0 +1,21 @@
+class MozillaPasswordsException(Exception):
+    """MozillaPasswords Base Exception"""
+    pass
+
+
+class NssLinkingError(MozillaPasswordsException):
+    """Indicates a failure to find the NSS library"""
+    pass
+
+
+class NssInitializationError(MozillaPasswordsException):
+    """Indicates a failure to initialize the NSS library"""
+    pass
+
+
+class Base64DecodingError(MozillaPasswordsException):
+    pass
+
+
+class PasswordDecryptionError(MozillaPasswordsException):
+    pass


### PR DESCRIPTION
Shortened the exception names, as "Failure" is usually synonymous with "Exception", or not really necessary in the name and can be provided by the exception's message IMHO.

BaseException "is not meant to be directly inherited by user-defined classes" (https://docs.python.org/2/library/exceptions.html#exceptions.BaseException), changed that.

Then I supposed if there is a 'decrypt.py' there might be an 'encrypt.py' later to share these, so I made them module-wide imports. Maybe they should just go into the `__init__.py` instead, not sure, I guess that depends on file layout TBD as part of #5.

This is a commit on top of PR #4.
